### PR TITLE
fix: resolve GitHub Package Registry publishing permissions

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish-beta:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
@@ -25,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      
+
       - name: Run linting
         run: yarn lint:check
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -26,6 +26,9 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     environment: release # Require approval for 'release' environment
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "lib/index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gildraen/discord-bot-modules-core.git"
+  },
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## 🐛 Problem
GitHub Package Registry publishing was failing with error:
> "Permission installation not allowed to Create organization package"

## ✅ Solution
Fixed two missing configurations required for organization-scoped package publishing:

### Changes Made:
1. **📦 Added repository field to `package.json`**
   - Links package to repository for proper permission inheritance
   - Required for organization-scoped packages (`@gildraen/`)

2. **🔐 Added explicit permissions to GitHub Actions workflows**
   - Added `packages: write` permission to all publishing workflows
   - Enables `GITHUB_TOKEN` to publish to GitHub Package Registry

### Files Changed:
- `package.json` - Added repository field
- `.github/workflows/beta.yml` - Added permissions block
- `.github/workflows/release.yml` - Added permissions block  
- `.github/workflows/manual-release.yml` - Added permissions block

## 🧪 Testing
- ✅ Package builds successfully locally
- ⏳ Will test publishing after merge

Fixes the publishing pipeline and enables automatic beta/release publishing.