### PR TITLE
feat: add version field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gildraen/dbm-core",
   "main": "lib/index.js",
+  "version": "0.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What
Add version field to package.json with initial value 0.0.0

## Why
- Ensures the package has a proper version for publishing to GitHub Package Registry
- Follows semantic versioning convention
- Required for proper npm package management

## Changes
- Added `"version": "0.0.0"` field to package.json