### PR TITLE
refactor(registry): type keys and kinds contract

### DIFF
--- a/src/domain/interface/registry/DescriptorInterface.ts
+++ b/src/domain/interface/registry/DescriptorInterface.ts
@@ -1,12 +1,13 @@
 import { REGISTRY_KINDS } from "../registry/types.js";
 import type { HandlerInterface, EventHandlerInterface } from "../handlers/HandlerInterface.js";
+import type { Kind, RegistryKey } from "../registry/types.js";
 
 /**
  * Descriptor for interaction-based handlers (commands, components, autocomplete)
  */
 export interface InteractionDescriptorInterface {
-    readonly key: string;
-    readonly kind: string;
+    readonly key: RegistryKey;
+    readonly kind: Kind;
     readonly metadata: Record<string, unknown>;
     readonly handlerClass: new () => HandlerInterface;
 }
@@ -15,7 +16,7 @@ export interface InteractionDescriptorInterface {
  * Descriptor for event-based handlers
  */
 export interface EventDescriptorInterface {
-    readonly key: string;
+    readonly key: RegistryKey;
     readonly kind: typeof REGISTRY_KINDS.EVENT;
     readonly metadata: Record<string, unknown>;
     readonly handlerClass: new () => EventHandlerInterface;

--- a/src/domain/interface/registry/RegistryInterface.ts
+++ b/src/domain/interface/registry/RegistryInterface.ts
@@ -1,4 +1,5 @@
 import type { DescriptorInterface } from "./DescriptorInterface.js";
+import type { Kind, RegistryKey } from "./types.js";
 
 /**
  * Registry interface for storing and retrieving handler descriptors
@@ -6,12 +7,12 @@ import type { DescriptorInterface } from "./DescriptorInterface.js";
 export interface RegistryInterface {
     // Write operations
     upsert(descriptor: DescriptorInterface): void;
-    remove(key: string): boolean;
-    clear(kind?: string): void;
+    remove(key: RegistryKey): boolean;
+    clear(kind?: Kind): void;
 
     // Read operations
-    get(key: string): DescriptorInterface | undefined;
-    list(kind?: string): ReadonlyArray<DescriptorInterface>;
-    has(key: string): boolean;
-    size(kind?: string): number;
+    get(key: RegistryKey): DescriptorInterface | undefined;
+    list(kind?: Kind): ReadonlyArray<DescriptorInterface>;
+    has(key: RegistryKey): boolean;
+    size(kind?: Kind): number;
 }

--- a/src/infrastructure/Registry.ts
+++ b/src/infrastructure/Registry.ts
@@ -1,8 +1,9 @@
 import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
 import type { DescriptorInterface } from "app/domain/interface/registry/DescriptorInterface.js";
+import type { Kind, RegistryKey } from "app/domain/interface/registry/types.js";
 
 export class Registry implements RegistryInterface {
-    private readonly descriptors = new Map<string, DescriptorInterface>();
+    private readonly descriptors = new Map<RegistryKey, DescriptorInterface>();
 
     upsert(descriptor: DescriptorInterface): void {
         if (this.descriptors.has(descriptor.key)) {
@@ -12,7 +13,7 @@ export class Registry implements RegistryInterface {
         console.log(`✅ Registered ${descriptor.kind}: ${descriptor.key}`);
     }
 
-    remove(key: string): boolean {
+    remove(key: RegistryKey): boolean {
         const existed = this.descriptors.has(key);
         if (existed) {
             this.descriptors.delete(key);
@@ -20,7 +21,7 @@ export class Registry implements RegistryInterface {
         return existed;
     }
 
-    clear(kind?: string): void {
+    clear(kind?: Kind): void {
         if (kind) {
             for (const [key, descriptor] of this.descriptors.entries()) {
                 if (descriptor.kind === kind) {
@@ -32,20 +33,20 @@ export class Registry implements RegistryInterface {
         }
     }
 
-    get(key: string): DescriptorInterface | undefined {
+    get(key: RegistryKey): DescriptorInterface | undefined {
         return this.descriptors.get(key);
     }
 
-    list(kind?: string): ReadonlyArray<DescriptorInterface> {
+    list(kind?: Kind): ReadonlyArray<DescriptorInterface> {
         const all = Array.from(this.descriptors.values());
         return kind ? all.filter(d => d.kind === kind) : all;
     }
 
-    has(key: string): boolean {
+    has(key: RegistryKey): boolean {
         return this.descriptors.has(key);
     }
 
-    size(kind?: string): number {
+    size(kind?: Kind): number {
         return kind ? this.list(kind).length : this.descriptors.size;
     }
 }


### PR DESCRIPTION
## Purpose
Stabilize the registry contract for step 1.1 by replacing loose string signatures with explicit registry key/kind types.

## Changes
- use RegistryKey/Kind in RegistryInterface
- tighten DescriptorInterface key/kind typing
- align infrastructure Registry implementation signatures

## Validation
- yarn lint:check
- yarn build
- yarn test

## Notes
- no runtime behavior changes intended