### PR TITLE
refactor(registry): decouple provider from infrastructure

### DIFF
--- a/src/domain/registry/DomainRegistry.ts
+++ b/src/domain/registry/DomainRegistry.ts
@@ -1,0 +1,55 @@
+import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
+import type { DescriptorInterface } from "app/domain/interface/registry/DescriptorInterface.js";
+import type { Kind, RegistryKey } from "app/domain/interface/registry/types.js";
+
+/**
+ * Domain-local registry implementation used by decorators and domain services.
+ */
+export class DomainRegistry implements RegistryInterface {
+    private readonly descriptors = new Map<RegistryKey, DescriptorInterface>();
+
+    upsert(descriptor: DescriptorInterface): void {
+        if (this.descriptors.has(descriptor.key)) {
+            console.warn(`⚠️  Overwriting registration for key: ${descriptor.key}`);
+        }
+        this.descriptors.set(descriptor.key, descriptor);
+        console.log(`✅ Registered ${descriptor.kind}: ${descriptor.key}`);
+    }
+
+    remove(key: RegistryKey): boolean {
+        const existed = this.descriptors.has(key);
+        if (existed) {
+            this.descriptors.delete(key);
+        }
+        return existed;
+    }
+
+    clear(kind?: Kind): void {
+        if (kind) {
+            for (const [key, descriptor] of this.descriptors.entries()) {
+                if (descriptor.kind === kind) {
+                    this.descriptors.delete(key);
+                }
+            }
+        } else {
+            this.descriptors.clear();
+        }
+    }
+
+    get(key: RegistryKey): DescriptorInterface | undefined {
+        return this.descriptors.get(key);
+    }
+
+    list(kind?: Kind): ReadonlyArray<DescriptorInterface> {
+        const all = Array.from(this.descriptors.values());
+        return kind ? all.filter(d => d.kind === kind) : all;
+    }
+
+    has(key: RegistryKey): boolean {
+        return this.descriptors.has(key);
+    }
+
+    size(kind?: Kind): number {
+        return kind ? this.list(kind).length : this.descriptors.size;
+    }
+}

--- a/src/domain/registry/RegistryProvider.ts
+++ b/src/domain/registry/RegistryProvider.ts
@@ -1,6 +1,6 @@
-import { Registry } from "app/infrastructure/Registry.js";
+import { DomainRegistry } from "./DomainRegistry.js";
 
 /**
  * Global registry singleton.
  */
-export const registry = new Registry();
+export const registry = new DomainRegistry();


### PR DESCRIPTION
## Purpose
Remove the forbidden Domain -> Infrastructure dependency from RegistryProvider.

## Changes
- add domain-local registry implementation ()
- update  to instantiate 
- keep behavior unchanged for decorators/services

## Validation
- yarn lint:check
- yarn build
- yarn test
- no  imports left under 

## Notes
- this is micro-PR 1.2 in step 1 decomposition