### PR TITLE
refactor(registry): inject RegistryInterface into domain services

### DIFF
--- a/src/application/useCase/RegisterCommands.ts
+++ b/src/application/useCase/RegisterCommands.ts
@@ -2,12 +2,13 @@ import { config } from "app/domain/config/Config.js";
 import { loadModule } from "app/domain/service/ModuleLoader.js";
 import { CommandRegistrationService } from "app/domain/service/CommandRegistrationService.js";
 import type { CommandRepository } from "app/domain/interface/repository/CommandRepository.js";
+import { registry } from "app/domain/registry/RegistryProvider.js";
 
 export class RegisterCommands {
     private readonly commandRegistrationService: CommandRegistrationService;
 
     public constructor(commandRepository: CommandRepository) {
-        this.commandRegistrationService = new CommandRegistrationService(commandRepository);
+        this.commandRegistrationService = new CommandRegistrationService(commandRepository, registry);
     }
 
     public async execute() {

--- a/src/application/useCase/RegisterListeners.ts
+++ b/src/application/useCase/RegisterListeners.ts
@@ -2,12 +2,13 @@ import { config } from "app/domain/config/Config.js";
 import { loadModule } from "app/domain/service/ModuleLoader.js";
 import { ListenerRegistrationService } from "app/domain/service/ListenerRegistrationService.js";
 import type { ListenerRepository } from "app/domain/interface/repository/ListenerRepository.js";
+import { registry } from "app/domain/registry/RegistryProvider.js";
 
 export class RegisterListeners {
     private readonly listenerRegistrationService: ListenerRegistrationService;
 
     public constructor(listenerRepository: ListenerRepository) {
-        this.listenerRegistrationService = new ListenerRegistrationService(listenerRepository);
+        this.listenerRegistrationService = new ListenerRegistrationService(listenerRepository, registry);
     }
 
     public async execute() {

--- a/src/domain/service/CommandRegistrationService.ts
+++ b/src/domain/service/CommandRegistrationService.ts
@@ -3,16 +3,18 @@ import type { CommandRepository } from "app/domain/interface/repository/CommandR
 import type { CommandHandlerInterface } from "app/domain/interface/handlers/HandlerInterface.js";
 import type { InteractionDescriptorInterface } from "app/domain/interface/registry/DescriptorInterface.js";
 import { isEventDescriptor } from "app/domain/interface/registry/DescriptorInterface.js";
-import { registry } from "app/domain/registry/RegistryProvider.js";
+import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
 
 /**
  * Domain service for command registration business logic
  */
 export class CommandRegistrationService {
     private readonly commandRepository: CommandRepository;
+    private readonly registry: RegistryInterface;
 
-    constructor(commandRepository: CommandRepository) {
+    constructor(commandRepository: CommandRepository, registry: RegistryInterface) {
         this.commandRepository = commandRepository;
+        this.registry = registry;
     }
 
     /**
@@ -47,7 +49,7 @@ export class CommandRegistrationService {
         ];
 
         return commandKinds.flatMap(kind =>
-            registry.list(kind)
+            this.registry.list(kind)
                 .filter((d): d is InteractionDescriptorInterface => !isEventDescriptor(d))
                 .map(descriptor => {
                     const handler = new descriptor.handlerClass() as CommandHandlerInterface;

--- a/src/domain/service/ListenerRegistrationService.ts
+++ b/src/domain/service/ListenerRegistrationService.ts
@@ -4,7 +4,7 @@ import type { EventDescriptorInterface, InteractionDescriptorInterface } from "a
 import { isEventDescriptor } from "app/domain/interface/registry/DescriptorInterface.js";
 import { REGISTRY_KINDS } from "app/domain/interface/registry/types.js";
 import { Keys } from "app/domain/keys/Keys.js";
-import { registry } from "app/domain/registry/RegistryProvider.js";
+import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
 
 /**
  * Domain service for listener setup business logic
@@ -12,9 +12,11 @@ import { registry } from "app/domain/registry/RegistryProvider.js";
 
 export class ListenerRegistrationService {
     private readonly listenerRepository: ListenerRepository;
+    private readonly registry: RegistryInterface;
 
-    constructor(listenerRepository: ListenerRepository) {
+    constructor(listenerRepository: ListenerRepository, registry: RegistryInterface) {
         this.listenerRepository = listenerRepository;
+        this.registry = registry;
     }
 
     /**
@@ -62,7 +64,7 @@ export class ListenerRegistrationService {
      * Register all event listeners discovered in registry
      */
     private registerEventListeners(failures: RegistrationFailure[]): number {
-        const eventDescriptors = registry.list(REGISTRY_KINDS.EVENT).filter(isEventDescriptor);
+        const eventDescriptors = this.registry.list(REGISTRY_KINDS.EVENT).filter(isEventDescriptor);
         let registeredEventListeners = 0;
 
         for (const descriptor of eventDescriptors) {
@@ -160,7 +162,7 @@ export class ListenerRegistrationService {
         key: string,
         interaction: Interaction
     ): InteractionDescriptorInterface | undefined {
-        const descriptor = registry.get(key);
+        const descriptor = this.registry.get(key);
         if (descriptor && !isEventDescriptor(descriptor)) {
             return descriptor;
         }
@@ -172,7 +174,7 @@ export class ListenerRegistrationService {
         }
 
         const fallbackKey = Keys.autocomplete(Keys.slash(interaction.commandName));
-        const fallback = registry.get(fallbackKey);
+        const fallback = this.registry.get(fallbackKey);
         return fallback && !isEventDescriptor(fallback) ? fallback : undefined;
     }
 
@@ -192,7 +194,7 @@ export class ListenerRegistrationService {
 
         const namespacedKey = Keys.component({ namespace, id: customId });
         // Backward-compatibility: fall back to legacy key when only old registrations exist.
-        return registry.has(namespacedKey)
+        return this.registry.has(namespacedKey)
             ? namespacedKey
             : Keys.component({ id: customId });
     }
@@ -244,8 +246,8 @@ export class ListenerRegistrationService {
         attachedEventListeners: number,
         failures: RegistrationFailure[]
     ): void {
-        const summary = registry.size();
-        const discoveredEventListeners = registry.size(REGISTRY_KINDS.EVENT);
+        const summary = this.registry.size();
+        const discoveredEventListeners = this.registry.size(REGISTRY_KINDS.EVENT);
         const discoveredInteractionHandlers = summary - discoveredEventListeners;
 
         console.log(`✅ Attached ${totalListeners} runtime listeners:`);
@@ -294,21 +296,21 @@ export class ListenerRegistrationService {
     } {
         // Sum all component kinds
         const componentCount =
-            registry.size(REGISTRY_KINDS.STRING_SELECT) +
-            registry.size(REGISTRY_KINDS.USER_SELECT) +
-            registry.size(REGISTRY_KINDS.ROLE_SELECT) +
-            registry.size(REGISTRY_KINDS.CHANNEL_SELECT) +
-            registry.size(REGISTRY_KINDS.MENTIONABLE_SELECT) +
-            registry.size(REGISTRY_KINDS.BUTTON) +
-            registry.size(REGISTRY_KINDS.MODAL);
+            this.registry.size(REGISTRY_KINDS.STRING_SELECT) +
+            this.registry.size(REGISTRY_KINDS.USER_SELECT) +
+            this.registry.size(REGISTRY_KINDS.ROLE_SELECT) +
+            this.registry.size(REGISTRY_KINDS.CHANNEL_SELECT) +
+            this.registry.size(REGISTRY_KINDS.MENTIONABLE_SELECT) +
+            this.registry.size(REGISTRY_KINDS.BUTTON) +
+            this.registry.size(REGISTRY_KINDS.MODAL);
 
         return {
-            events: registry.size(REGISTRY_KINDS.EVENT),
-            slashCommands: registry.size(REGISTRY_KINDS.SLASH),
-            contextMenus: registry.size(REGISTRY_KINDS.CONTEXT_USER) + registry.size(REGISTRY_KINDS.CONTEXT_MESSAGE),
+            events: this.registry.size(REGISTRY_KINDS.EVENT),
+            slashCommands: this.registry.size(REGISTRY_KINDS.SLASH),
+            contextMenus: this.registry.size(REGISTRY_KINDS.CONTEXT_USER) + this.registry.size(REGISTRY_KINDS.CONTEXT_MESSAGE),
             components: componentCount,
-            autocomplete: registry.size(REGISTRY_KINDS.AUTOCOMPLETE),
-            total: registry.size()
+            autocomplete: this.registry.size(REGISTRY_KINDS.AUTOCOMPLETE),
+            total: this.registry.size()
         };
     }
 }

--- a/tests/application/useCase/RegisterCommands.test.ts
+++ b/tests/application/useCase/RegisterCommands.test.ts
@@ -60,7 +60,7 @@ describe("RegisterCommands", () => {
 
         await useCase.execute();
 
-        expect(mocks.CommandRegistrationService).toHaveBeenCalledWith(commandRepository);
+        expect(mocks.CommandRegistrationService).toHaveBeenCalledWith(commandRepository, expect.any(Object));
         expect(mocks.loadModule).toHaveBeenNthCalledWith(1, "module-a");
         expect(mocks.loadModule).toHaveBeenNthCalledWith(2, "module-b");
         expect(moduleA.discoverCommands).toHaveBeenCalledTimes(1);

--- a/tests/application/useCase/RegisterListeners.test.ts
+++ b/tests/application/useCase/RegisterListeners.test.ts
@@ -61,7 +61,7 @@ describe("RegisterListeners", () => {
 
         await useCase.execute();
 
-        expect(mocks.ListenerRegistrationService).toHaveBeenCalledWith(listenerRepository);
+        expect(mocks.ListenerRegistrationService).toHaveBeenCalledWith(listenerRepository, expect.any(Object));
         expect(mocks.loadModule).toHaveBeenNthCalledWith(1, "module-a");
         expect(mocks.loadModule).toHaveBeenNthCalledWith(2, "module-b");
         expect(moduleA.discoverListeners).toHaveBeenCalledTimes(1);

--- a/tests/domain/service/CommandRegistrationService.test.ts
+++ b/tests/domain/service/CommandRegistrationService.test.ts
@@ -4,11 +4,6 @@ import type { RegistryInterface } from "app/domain/interface/registry/RegistryIn
 import type { DescriptorInterface } from "app/domain/interface/registry/DescriptorInterface.js";
 import { REGISTRY_KINDS } from "app/domain/interface/registry/types.js";
 
-let mockRegistry: RegistryInterface;
-
-vi.mock("app/domain/registry/RegistryProvider.js", () => ({
-    get registry() { return mockRegistry; },
-}));
 import { CommandRegistrationService } from "app/domain/service/CommandRegistrationService.js";
 
 // ---------------------------------------------------------------------------
@@ -67,7 +62,6 @@ describe("CommandRegistrationService", () => {
         vi.spyOn(console, "log").mockImplementation(() => undefined);
         vi.spyOn(console, "warn").mockImplementation(() => undefined);
         vi.spyOn(console, "error").mockImplementation(() => undefined);
-        mockRegistry = makeRegistry();
     });
 
     afterEach(() => {
@@ -82,8 +76,7 @@ describe("CommandRegistrationService", () => {
         test("returns 0 and does not call repository when registry is empty", async () => {
             const repository = makeRepository();
             const registry = makeRegistry();
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -104,8 +97,7 @@ describe("CommandRegistrationService", () => {
             const registry = makeRegistry({
                 [REGISTRY_KINDS.SLASH]: [descriptor],
             });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -119,8 +111,7 @@ describe("CommandRegistrationService", () => {
             const registry = makeRegistry({
                 [REGISTRY_KINDS.CONTEXT_USER]: [descriptor],
             });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -134,8 +125,7 @@ describe("CommandRegistrationService", () => {
             const registry = makeRegistry({
                 [REGISTRY_KINDS.CONTEXT_MESSAGE]: [descriptor],
             });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -153,8 +143,7 @@ describe("CommandRegistrationService", () => {
                 [REGISTRY_KINDS.CONTEXT_USER]: [userDescriptor],
                 [REGISTRY_KINDS.CONTEXT_MESSAGE]: [msgDescriptor],
             });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -170,8 +159,7 @@ describe("CommandRegistrationService", () => {
             const descriptor = makeDescriptor("slash:ping", REGISTRY_KINDS.SLASH, SLASH_CMD);
             const repository = makeRepository(0); // repository reports 0 registered
             const registry = makeRegistry({ [REGISTRY_KINDS.SLASH]: [descriptor] });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             const result = await service.registerDiscoveredCommands();
 
@@ -188,8 +176,7 @@ describe("CommandRegistrationService", () => {
             const descriptor = makeDescriptor("slash:ping", REGISTRY_KINDS.SLASH, SLASH_CMD);
             const repository = makeRepository(1);
             const registry = makeRegistry({ [REGISTRY_KINDS.SLASH]: [descriptor] });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             await service.registerDiscoveredCommands();
 
@@ -206,8 +193,7 @@ describe("CommandRegistrationService", () => {
                 [REGISTRY_KINDS.SLASH]: [slashDescriptor],
                 [REGISTRY_KINDS.CONTEXT_USER]: [userDescriptor],
             });
-            mockRegistry = registry;
-            const service = new CommandRegistrationService(repository);
+            const service = new CommandRegistrationService(repository, registry);
 
             await service.registerDiscoveredCommands();
 

--- a/tests/domain/service/ListenerRegistrationService.test.ts
+++ b/tests/domain/service/ListenerRegistrationService.test.ts
@@ -5,11 +5,6 @@ import type { DescriptorInterface } from "app/domain/interface/registry/Descript
 import type { Interaction } from "app/domain/interface/InteractionHandler.js";
 import { REGISTRY_KINDS } from "app/domain/interface/registry/types.js";
 
-let mockRegistry: RegistryInterface;
-
-vi.mock("app/domain/registry/RegistryProvider.js", () => ({
-    get registry() { return mockRegistry; },
-}));
 import { Keys } from "app/domain/keys/Keys.js";
 import { ListenerRegistrationService } from "app/domain/service/ListenerRegistrationService.js";
 
@@ -81,7 +76,6 @@ describe("ListenerRegistrationService", () => {
         vi.spyOn(console, "log").mockImplementation(() => undefined);
         vi.spyOn(console, "warn").mockImplementation(() => undefined);
         vi.spyOn(console, "error").mockImplementation(() => undefined);
-        mockRegistry = makeRegistry();
     });
 
     afterEach(() => {
@@ -95,8 +89,8 @@ describe("ListenerRegistrationService", () => {
     describe("registerDiscoveredListeners()", () => {
         test("registers the interaction router and returns 1 when no event listeners", () => {
             const { repository } = makeRepository();
-            mockRegistry = makeRegistry();
-            const service = new ListenerRegistrationService(repository);
+            const registry = makeRegistry();
+            const service = new ListenerRegistrationService(repository, registry);
 
             const total = service.registerDiscoveredListeners();
 
@@ -107,11 +101,11 @@ describe("ListenerRegistrationService", () => {
         test("returns 1 + N when N event descriptors are found", () => {
             const { descriptor: evt1 } = makeDescriptor(Keys.event("messageCreate"), REGISTRY_KINDS.EVENT);
             const { descriptor: evt2 } = makeDescriptor(Keys.event("guildMemberAdd"), REGISTRY_KINDS.EVENT);
-            mockRegistry = makeRegistry({
+            const registry = makeRegistry({
                 list: vi.fn().mockReturnValue([evt1, evt2]),
             });
             const { repository } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             const total = service.registerDiscoveredListeners();
 
@@ -129,11 +123,11 @@ describe("ListenerRegistrationService", () => {
                 get handlerClass(): never { throw new Error("boom"); },
             } as unknown as DescriptorInterface;
 
-            mockRegistry = makeRegistry({
+            const registry = makeRegistry({
                 list: vi.fn().mockReturnValue([badDescriptor, goodDescriptor]),
             });
             const { repository } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             const total = service.registerDiscoveredListeners();
 
@@ -143,14 +137,14 @@ describe("ListenerRegistrationService", () => {
         });
 
         test("isolates interaction router failure and returns 0 listeners from router", () => {
-            mockRegistry = makeRegistry();
+            const registry = makeRegistry();
             const repository: ListenerRepository = {
                 registerInteractionListener: vi.fn(() => { throw new Error("router failed"); }),
                 registerEventHandlerClass: vi.fn(),
                 registerEventListener: vi.fn(),
                 getListenerSummary: vi.fn().mockReturnValue({ eventListeners: 0, interactionListeners: 0, total: 0 }),
             } as unknown as ListenerRepository;
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             const total = service.registerDiscoveredListeners();
 
@@ -166,9 +160,9 @@ describe("ListenerRegistrationService", () => {
     describe("event listener once flag propagation", () => {
         test("passes once=true when event metadata.once is true", () => {
             const { descriptor } = makeDescriptor(Keys.event("ready"), REGISTRY_KINDS.EVENT, { once: true });
-            mockRegistry = makeRegistry({ list: vi.fn().mockReturnValue([descriptor]) });
+            const registry = makeRegistry({ list: vi.fn().mockReturnValue([descriptor]) });
             const { repository } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             service.registerDiscoveredListeners();
 
@@ -181,9 +175,9 @@ describe("ListenerRegistrationService", () => {
 
         test("passes once=undefined when event metadata.once is not set", () => {
             const { descriptor } = makeDescriptor(Keys.event("messageCreate"), REGISTRY_KINDS.EVENT);
-            mockRegistry = makeRegistry({ list: vi.fn().mockReturnValue([descriptor]) });
+            const registry = makeRegistry({ list: vi.fn().mockReturnValue([descriptor]) });
             const { repository } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             service.registerDiscoveredListeners();
 
@@ -200,33 +194,33 @@ describe("ListenerRegistrationService", () => {
     // -----------------------------------------------------------------------
 
     describe("interaction routing", () => {
-        async function getHandler(): Promise<(interaction: Interaction) => Promise<unknown>> {
+        async function getHandler(registry: RegistryInterface = makeRegistry()): Promise<(interaction: Interaction) => Promise<unknown>> {
             const { repository, getRouterHandler } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
             service.registerDiscoveredListeners();
             return getRouterHandler();
         }
 
         test("routes slash interaction to handler via slash key", async () => {
             const { descriptor, handleSpy } = makeDescriptor(Keys.slash("ping"), REGISTRY_KINDS.SLASH);
-            mockRegistry = makeRegistry({
+            const registry = makeRegistry({
                 get: vi.fn().mockReturnValue(descriptor),
             });
-            const handler = await getHandler();
+            const handler = await getHandler(registry);
 
             await handler({ type: "slash", commandName: "ping", id: "1" });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(Keys.slash("ping"));
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(Keys.slash("ping"));
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
         test("routes slash interaction with subcommand group + subcommand to composite key", async () => {
             const key = Keys.slash("admin", "user", "ban");
             const { descriptor, handleSpy } = makeDescriptor(key, REGISTRY_KINDS.SLASH);
-            mockRegistry = makeRegistry({
+            const registry = makeRegistry({
                 get: vi.fn().mockReturnValue(descriptor),
             });
-            const handler = await getHandler();
+            const handler = await getHandler(registry);
 
             await handler({
                 type: "slash",
@@ -236,31 +230,31 @@ describe("ListenerRegistrationService", () => {
                 id: "1",
             });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
         test("routes context:user interaction to handler via contextUser key", async () => {
             const key = Keys.contextUser("Check Profile");
             const { descriptor, handleSpy } = makeDescriptor(key, REGISTRY_KINDS.CONTEXT_USER);
-            mockRegistry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
+            const handler = await getHandler(registry);
 
             await handler({ type: "context:user", commandName: "Check Profile", id: "1" });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
         test("routes context:message interaction to handler via contextMessage key", async () => {
             const key = Keys.contextMessage("Analyze Text");
             const { descriptor, handleSpy } = makeDescriptor(key, REGISTRY_KINDS.CONTEXT_MESSAGE);
-            mockRegistry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
+            const handler = await getHandler(registry);
 
             await handler({ type: "context:message", commandName: "Analyze Text", id: "1" });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
@@ -269,8 +263,8 @@ describe("ListenerRegistrationService", () => {
             const { descriptor, handleSpy } = makeDescriptor(namespacedKey, REGISTRY_KINDS.STRING_SELECT);
             const getMock = vi.fn().mockReturnValue(descriptor);
             const hasMock = vi.fn().mockReturnValue(true); // namespaced key exists
-            mockRegistry = makeRegistry({ get: getMock, has: hasMock });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: getMock, has: hasMock });
+            const handler = await getHandler(registry);
 
             await handler({ type: "component", customId: "poll", componentType: "string-select", id: "1" });
 
@@ -285,8 +279,8 @@ describe("ListenerRegistrationService", () => {
             const namespacedKey = Keys.component({ namespace: "string-select", id: "poll" });
             const hasMock = vi.fn().mockReturnValue(false); // namespaced key does NOT exist
             const getMock = vi.fn((key: string) => (key === legacyKey ? descriptor : undefined)) as unknown as RegistryInterface["get"];
-            mockRegistry = makeRegistry({ get: getMock, has: hasMock });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: getMock, has: hasMock });
+            const handler = await getHandler(registry);
 
             await handler({ type: "component", customId: "poll", componentType: "string-select", id: "1" });
 
@@ -298,20 +292,20 @@ describe("ListenerRegistrationService", () => {
         test("routes component interaction without componentType via legacy key", async () => {
             const legacyKey = Keys.component({ id: "confirm" });
             const { descriptor, handleSpy } = makeDescriptor(legacyKey, REGISTRY_KINDS.BUTTON);
-            mockRegistry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
+            const handler = await getHandler(registry);
 
             await handler({ type: "component", customId: "confirm", id: "1" });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(legacyKey);
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(legacyKey);
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
         test("routes autocomplete interaction via option-specific key", async () => {
             const key = Keys.autocomplete(Keys.slash("search"), "query");
             const { descriptor, handleSpy } = makeDescriptor(key, REGISTRY_KINDS.AUTOCOMPLETE);
-            mockRegistry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: vi.fn().mockReturnValue(descriptor) });
+            const handler = await getHandler(registry);
 
             await handler({
                 type: "autocomplete",
@@ -320,7 +314,7 @@ describe("ListenerRegistrationService", () => {
                 id: "1",
             });
 
-            expect(mockRegistry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
+            expect(registry.get as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(key);
             expect(handleSpy).toHaveBeenCalledTimes(1);
         });
 
@@ -328,8 +322,8 @@ describe("ListenerRegistrationService", () => {
             const fallbackKey = Keys.autocomplete(Keys.slash("search"));
             const { descriptor, handleSpy } = makeDescriptor(fallbackKey, REGISTRY_KINDS.AUTOCOMPLETE);
             const getMock = vi.fn((key: string) => (key === fallbackKey ? descriptor : undefined)) as unknown as RegistryInterface["get"];
-            mockRegistry = makeRegistry({ get: getMock });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: getMock });
+            const handler = await getHandler(registry);
 
             await handler({
                 type: "autocomplete",
@@ -345,8 +339,8 @@ describe("ListenerRegistrationService", () => {
         });
 
         test("logs a warning when no handler is found for an interaction", async () => {
-            mockRegistry = makeRegistry({ get: vi.fn().mockReturnValue(undefined) });
-            const handler = await getHandler();
+            const registry = makeRegistry({ get: vi.fn().mockReturnValue(undefined) });
+            const handler = await getHandler(registry);
 
             await handler({ type: "slash", commandName: "unknown", id: "1" });
 
@@ -356,7 +350,6 @@ describe("ListenerRegistrationService", () => {
         });
 
         test("logs error and does not throw for component interaction with missing customId", async () => {
-            mockRegistry = makeRegistry();
             const handler = await getHandler();
 
             await expect(
@@ -366,7 +359,6 @@ describe("ListenerRegistrationService", () => {
         });
 
         test("logs error and does not throw for slash interaction with missing commandName", async () => {
-            mockRegistry = makeRegistry();
             const handler = await getHandler();
 
             await expect(
@@ -391,9 +383,9 @@ describe("ListenerRegistrationService", () => {
                 if (kind === REGISTRY_KINDS.AUTOCOMPLETE) return 4;
                 return 0;
             });
-            mockRegistry = makeRegistry({ size: sizeMock });
+            const registry = makeRegistry({ size: sizeMock });
             const { repository } = makeRepository();
-            const service = new ListenerRegistrationService(repository);
+            const service = new ListenerRegistrationService(repository, registry);
 
             const summary = service.getRegistrationSummary();
 


### PR DESCRIPTION
## Purpose
Wire domain services to receive RegistryInterface via constructor instead of reading the global singleton directly.

## Changes
- `CommandRegistrationService`: add `registry: RegistryInterface` constructor param
- `ListenerRegistrationService`: same
- `RegisterCommands` / `RegisterListeners` use cases: pass global registry from RegistryProvider at composition point
- Remove `vi.mock(RegistryProvider)` from both service tests; pass registry directly to constructors
- Update use case tests assertions to expect the registry argument

## Validation
- yarn lint:check
- yarn build
- yarn test (44/44)

## Notes
- micro-PR 1.4 in step 1 decomposition
- RegistryProvider still provides the singleton as before; this PR moves consumption to injection