### PR TITLE
test(architecture): guard domain-infrastructure boundary

### DIFF
--- a/tests/application/useCase/RegisterCommands.test.ts
+++ b/tests/application/useCase/RegisterCommands.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { CommandRepository } from "app/domain/interface/repository/CommandRepository.js";
-import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
 
 const mocks = vi.hoisted(() => {
     const getEnabledModules = vi.fn();
     const loadModule = vi.fn();
     const registerDiscoveredCommands = vi.fn();
+    const injectedRegistry = {};
     const CommandRegistrationService = vi.fn().mockImplementation(() => ({
         registerDiscoveredCommands,
     }));
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
         getEnabledModules,
         loadModule,
         registerDiscoveredCommands,
+        injectedRegistry,
         CommandRegistrationService,
     };
 });
@@ -30,6 +31,10 @@ vi.mock("app/domain/service/ModuleLoader.js", () => ({
 
 vi.mock("app/domain/service/CommandRegistrationService.js", () => ({
     CommandRegistrationService: mocks.CommandRegistrationService,
+}));
+
+vi.mock("app/domain/registry/RegistryProvider.js", () => ({
+    registry: mocks.injectedRegistry,
 }));
 
 import { RegisterCommands } from "app/application/useCase/RegisterCommands.js";
@@ -55,12 +60,11 @@ describe("RegisterCommands", () => {
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
         const commandRepository = {} as CommandRepository;
-        const registry = {} as RegistryInterface;
         const useCase = new RegisterCommands(commandRepository);
 
         await useCase.execute();
 
-        expect(mocks.CommandRegistrationService).toHaveBeenCalledWith(commandRepository, expect.any(Object));
+        expect(mocks.CommandRegistrationService).toHaveBeenCalledWith(commandRepository, mocks.injectedRegistry);
         expect(mocks.loadModule).toHaveBeenNthCalledWith(1, "module-a");
         expect(mocks.loadModule).toHaveBeenNthCalledWith(2, "module-b");
         expect(moduleA.discoverCommands).toHaveBeenCalledTimes(1);

--- a/tests/application/useCase/RegisterListeners.test.ts
+++ b/tests/application/useCase/RegisterListeners.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { ListenerRepository } from "app/domain/interface/repository/ListenerRepository.js";
-import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
 
 const mocks = vi.hoisted(() => {
     const getEnabledModules = vi.fn();
     const loadModule = vi.fn();
     const registerDiscoveredListeners = vi.fn();
+    const injectedRegistry = {};
     const ListenerRegistrationService = vi.fn().mockImplementation(() => ({
         registerDiscoveredListeners,
     }));
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
         getEnabledModules,
         loadModule,
         registerDiscoveredListeners,
+        injectedRegistry,
         ListenerRegistrationService,
     };
 });
@@ -30,6 +31,10 @@ vi.mock("app/domain/service/ModuleLoader.js", () => ({
 
 vi.mock("app/domain/service/ListenerRegistrationService.js", () => ({
     ListenerRegistrationService: mocks.ListenerRegistrationService,
+}));
+
+vi.mock("app/domain/registry/RegistryProvider.js", () => ({
+    registry: mocks.injectedRegistry,
 }));
 
 import { RegisterListeners } from "app/application/useCase/RegisterListeners.js";
@@ -56,12 +61,11 @@ describe("RegisterListeners", () => {
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
         const listenerRepository = {} as ListenerRepository;
-        const registry = {} as RegistryInterface;
         const useCase = new RegisterListeners(listenerRepository);
 
         await useCase.execute();
 
-        expect(mocks.ListenerRegistrationService).toHaveBeenCalledWith(listenerRepository, expect.any(Object));
+        expect(mocks.ListenerRegistrationService).toHaveBeenCalledWith(listenerRepository, mocks.injectedRegistry);
         expect(mocks.loadModule).toHaveBeenNthCalledWith(1, "module-a");
         expect(mocks.loadModule).toHaveBeenNthCalledWith(2, "module-b");
         expect(moduleA.discoverListeners).toHaveBeenCalledTimes(1);

--- a/tests/integration/ArchitectureBoundaries.test.ts
+++ b/tests/integration/ArchitectureBoundaries.test.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, test } from "vitest";
+
+function collectTsFiles(dirPath: string): string[] {
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...collectTsFiles(fullPath));
+            continue;
+        }
+
+        if (entry.isFile() && fullPath.endsWith(".ts")) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+}
+
+describe("Architecture boundaries", () => {
+    test("domain layer must not import infrastructure layer", () => {
+        const domainRoot = path.resolve(process.cwd(), "src/domain");
+        const files = collectTsFiles(domainRoot);
+        const violations: string[] = [];
+
+        for (const filePath of files) {
+            const content = fs.readFileSync(filePath, "utf8");
+            if (content.includes('from "app/infrastructure') || content.includes("from 'app/infrastructure")) {
+                violations.push(path.relative(process.cwd(), filePath));
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Purpose
Add a regression safety net for Step 1 by locking critical architecture and wiring behavior through tests.

## Changes
- strengthen use case tests to assert the exact injected registry from RegistryProvider
- add architecture boundary integration test to prevent  importing 
- keep production code unchanged

## Validation
- yarn lint:check
- yarn build
- yarn test (45/45)

## Notes
- micro-PR 1.5 in step 1 decomposition
- this closes Step 1 with a permanent anti-regression guard