### PR TITLE
feat(runtime): introduce RuntimeContext interface in application layer

### DIFF
--- a/src/application/interface/RuntimeContext.ts
+++ b/src/application/interface/RuntimeContext.ts
@@ -1,0 +1,12 @@
+import type { RegistryInterface } from "app/domain/interface/registry/RegistryInterface.js";
+
+/**
+ * Runtime context passed through the application layer.
+ * Carries the registry instance for a given execution lifecycle
+ * (CLI registration, bot runtime, or test).
+ *
+ * Replaces implicit access to the global registry singleton.
+ */
+export interface RuntimeContext {
+    registry: RegistryInterface;
+}


### PR DESCRIPTION
## Purpose

Introduce a `RuntimeContext` interface in the application layer as the first step toward explicit context propagation.

## Changes

- Add `src/application/interface/RuntimeContext.ts` with `RuntimeContext` interface wrapping `RegistryInterface`
- Pure additive change — no behavior altered

## Testing

- [x] All tests pass (45/45)
- [x] Lint clean
- [x] No regressions

## Notes

This is PR 2.1 of the runtime context refactor series.
Next: PR 2.2 will inject this context into `RegisterCommands` and `RegisterListeners` use cases, replacing direct global registry access.