### PR TITLE
refactor(runtime): inject RuntimeContext into use cases

### DIFF
--- a/src/application/useCase/RegisterCommands.ts
+++ b/src/application/useCase/RegisterCommands.ts
@@ -3,12 +3,14 @@ import { loadModule } from "app/domain/service/ModuleLoader.js";
 import { CommandRegistrationService } from "app/domain/service/CommandRegistrationService.js";
 import type { CommandRepository } from "app/domain/interface/repository/CommandRepository.js";
 import { registry } from "app/domain/registry/RegistryProvider.js";
+import type { RuntimeContext } from "app/application/interface/RuntimeContext.js";
 
 export class RegisterCommands {
     private readonly commandRegistrationService: CommandRegistrationService;
 
-    public constructor(commandRepository: CommandRepository) {
-        this.commandRegistrationService = new CommandRegistrationService(commandRepository, registry);
+    public constructor(commandRepository: CommandRepository, context?: RuntimeContext) {
+        const activeRegistry = context?.registry ?? registry;
+        this.commandRegistrationService = new CommandRegistrationService(commandRepository, activeRegistry);
     }
 
     public async execute() {

--- a/src/application/useCase/RegisterListeners.ts
+++ b/src/application/useCase/RegisterListeners.ts
@@ -3,12 +3,14 @@ import { loadModule } from "app/domain/service/ModuleLoader.js";
 import { ListenerRegistrationService } from "app/domain/service/ListenerRegistrationService.js";
 import type { ListenerRepository } from "app/domain/interface/repository/ListenerRepository.js";
 import { registry } from "app/domain/registry/RegistryProvider.js";
+import type { RuntimeContext } from "app/application/interface/RuntimeContext.js";
 
 export class RegisterListeners {
     private readonly listenerRegistrationService: ListenerRegistrationService;
 
-    public constructor(listenerRepository: ListenerRepository) {
-        this.listenerRegistrationService = new ListenerRegistrationService(listenerRepository, registry);
+    public constructor(listenerRepository: ListenerRepository, context?: RuntimeContext) {
+        const activeRegistry = context?.registry ?? registry;
+        this.listenerRegistrationService = new ListenerRegistrationService(listenerRepository, activeRegistry);
     }
 
     public async execute() {

--- a/tests/application/useCase/RegisterCommands.test.ts
+++ b/tests/application/useCase/RegisterCommands.test.ts
@@ -111,4 +111,17 @@ describe("RegisterCommands", () => {
             "❌ Failed to register commands with Discord: Discord API unavailable"
         );
     });
+
+    test("uses registry from explicit RuntimeContext when provided", async () => {
+        mocks.getEnabledModules.mockReturnValue([]);
+        mocks.registerDiscoveredCommands.mockResolvedValue(undefined);
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        const explicitRegistry = { id: "explicit" };
+        const commandRepository = {} as CommandRepository;
+        const useCase = new RegisterCommands(commandRepository, { registry: explicitRegistry as never });
+        await useCase.execute();
+
+        expect(mocks.CommandRegistrationService).toHaveBeenCalledWith(commandRepository, explicitRegistry);
+    });
 });

--- a/tests/application/useCase/RegisterListeners.test.ts
+++ b/tests/application/useCase/RegisterListeners.test.ts
@@ -117,4 +117,18 @@ describe("RegisterListeners", () => {
             "❌ Failed to register listeners with Discord: Registry unavailable"
         );
     });
+
+    test("uses registry from explicit RuntimeContext when provided", async () => {
+        mocks.getEnabledModules.mockReturnValue([]);
+        mocks.registerDiscoveredListeners.mockReturnValue(0);
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+        const explicitRegistry = { id: "explicit" };
+        const listenerRepository = {} as ListenerRepository;
+        const useCase = new RegisterListeners(listenerRepository, { registry: explicitRegistry as never });
+        await useCase.execute();
+
+        expect(mocks.ListenerRegistrationService).toHaveBeenCalledWith(listenerRepository, explicitRegistry);
+    });
 });


### PR DESCRIPTION
## Purpose

Inject `RuntimeContext` into `RegisterCommands` and `RegisterListeners` use cases, replacing direct implicit access to the global registry singleton.

## Changes

- `RegisterCommands`: accepts optional `context?: RuntimeContext`; uses `context.registry` when provided, falls back to global `registry` for full backward compatibility
- `RegisterListeners`: same pattern
- Tests: 2 new assertions verifying that when a context is passed, its registry is forwarded to the domain services

## Testing

- [x] All tests pass (47/47)
- [x] Lint clean
- [x] No regressions — all existing callers (Runtime.ts, CLI, RegisterCommandsOnReadyEvent) work unchanged

## Notes

This is PR 2.2 of the runtime context refactor series.
The global registry fallback is intentional and temporary — it will be removed once decorators are migrated off the singleton (PR 2.3+).