### PR TITLE
test(runtime): add helpers for isolated RuntimeContext in tests

### DIFF
--- a/tests/application/helpers/RuntimeContextHelpers.ts
+++ b/tests/application/helpers/RuntimeContextHelpers.ts
@@ -1,0 +1,39 @@
+import { DomainRegistry } from "app/domain/registry/DomainRegistry.js";
+import type { RuntimeContext } from "app/application/interface/RuntimeContext.js";
+
+/**
+ * Create an isolated RuntimeContext for testing.
+ * Each call returns a fresh context with its own registry instance.
+ *
+ * @returns A new RuntimeContext with an isolated DomainRegistry
+ *
+ * @example
+ * ```typescript
+ * const context = createIsolatedContext();
+ * const useCase = new RegisterCommands(repository, context);
+ * await useCase.execute();
+ * clearContext(context); // Clean up after test
+ * ```
+ */
+export function createIsolatedContext(): RuntimeContext {
+    return {
+        registry: new DomainRegistry(),
+    };
+}
+
+/**
+ * Clear all entries in a context's registry.
+ * Use this in test teardown to prevent state leakage between tests.
+ *
+ * @param context The RuntimeContext to clear
+ *
+ * @example
+ * ```typescript
+ * afterEach(() => {
+ *     clearContext(context);
+ * });
+ * ```
+ */
+export function clearContext(context: RuntimeContext): void {
+    context.registry.clear();
+}


### PR DESCRIPTION
## Purpose

Add test helpers to support isolated RuntimeContext instances for unit and integration tests.
This enables tests to work with their own registry instance instead of relying on the global singleton.

## Changes

- `tests/application/helpers/RuntimeContextHelpers.ts`: two helper functions:
  - `createIsolatedContext()` — creates a fresh RuntimeContext with isolated DomainRegistry
  - `clearContext(context)` — clears all entries in a context's registry for cleanup

## Testing

- [x] All tests pass (47/47)
- [x] Lint clean
- [x] No regressions

## Notes

This is PR 2.3 of the runtime context refactor series.
These helpers are prepared for future use when decorators migrate off the global singleton.
Currently, the global registryProvider is still used for end-to-end tests (decorators still write to global state).