### PR TITLE
refactor(api): reduce public surface to module-first bootstrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,11 @@
 import { type ModuleInterface } from "app/domain/interface/ModuleInterface.js";
 import { type Interaction } from "app/domain/interface/InteractionHandler.js";
-import { registerApplication, registerListeners, registerCommands } from "app/infrastructure/runtime/Runtime.js";
+import { registerApplication } from "app/infrastructure/runtime/Runtime.js";
 
 export {
     type ModuleInterface,
     type Interaction,
     registerApplication,
-    registerListeners,
-    registerCommands,
 };
 
 // Decorators


### PR DESCRIPTION
## Purpose

Aligns the public API with the module-first vision: developers using the library only need:
- ModuleInterface
- Decorators 
- registerApplication bootstrap

## Changes

- Remove registerListeners export from public API
- Remove registerCommands export from public API
- Both remain available internally for infrastructure composition

## Impact

- Cleaner public surface, easier discoverability
- Reduces confusion about what's for module developers vs internal orchestration
- No breaking change for current usage (examples use registerApplication)

## Testing

- yarn lint:check ✓
- yarn build ✓
- yarn test (to verify)